### PR TITLE
Replace failure with anyhow and thiserror.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-failure = "0.1.5"
+anyhow = "1.0"
+thiserror = "1.0"
 serde_json = "1.0.39"
 
 [dependencies.chrono]

--- a/src/batcher.rs
+++ b/src/batcher.rs
@@ -2,7 +2,7 @@
 
 use crate::errors::Error as AnalyticsError;
 use crate::message::{Batch, BatchMessage, Message};
-use failure::Error;
+use anyhow::Error;
 use serde_json::{Map, Value};
 
 const MAX_MESSAGE_SIZE: usize = 1024 * 32;
@@ -153,7 +153,7 @@ mod tests {
         let result = batcher.push(batch_msg.into());
 
         let err = result.err().unwrap();
-        let err: &AnalyticsError = err.as_fail().downcast_ref().unwrap();
+        let err: &AnalyticsError = err.downcast_ref().unwrap();
 
         match err {
             AnalyticsError::MessageTooLarge => {}

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,7 @@
 //! Interfaces to the Segment tracking API.
 
 use crate::message::Message;
-use failure::Error;
+use anyhow::Result;
 
 /// `Client` is a trait representing the HTTP transport layer of the analytics library.
 pub trait Client {
@@ -10,5 +10,5 @@ pub trait Client {
     /// A `write_key` is an API key for Segment's tracking API. See [Segment's
     /// documentation](https://segment.com/docs/guides/setup/how-do-i-find-my-write-key/)
     /// for how to find this value.
-    fn send(&self, write_key: &str, msg: &Message) -> Result<(), Error>;
+    fn send(&self, write_key: &str, msg: &Message) -> Result<()>;
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,12 +1,11 @@
 //! Errors which may arise from this crate.
 
-use failure::Fail;
+use thiserror::Error;
 
-/// An enum of errors this crate may produce. These are compatible with
-/// `failure` errors.
-#[derive(Debug, Fail)]
+/// An enum of errors this crate may produce.
+#[derive(Debug, Error)]
 pub enum Error {
     /// The given message is too large to be sent to Segment's API.
-    #[fail(display = "message too large")]
+    #[error("message too large")]
     MessageTooLarge,
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -2,7 +2,7 @@
 
 use crate::client::Client;
 use crate::message::Message;
-use failure::Error;
+use anyhow::Result;
 use std::time::Duration;
 
 /// A client which synchronously sends single messages to the Segment tracking
@@ -40,7 +40,7 @@ impl HttpClient {
 }
 
 impl Client for HttpClient {
-    fn send(&self, write_key: &str, msg: &Message) -> Result<(), Error> {
+    fn send(&self, write_key: &str, msg: &Message) -> Result<()> {
         let path = match msg {
             Message::Identify(_) => "/v1/identify",
             Message::Track(_) => "/v1/track",


### PR DESCRIPTION
The `failure` crate is no longer maintained and has been superseded by `anyhow` and `thiserror`.  Switching to these allows us to be able to inspect the contents of an error using `anyhow::Error::downcast_ref()` (it doesn't appear to work on an error produced by `failure`), which we can use to stop reporting client errors to Sentry (e.g.: HTTP connection issues).