### PR TITLE
Set a value for connection pool idle timeout to avoid errors.

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -19,7 +19,13 @@ impl Default for HttpClient {
     fn default() -> Self {
         HttpClient {
             client: reqwest::blocking::Client::builder()
-                .connect_timeout(Duration::new(10, 0))
+                // Keep idle connections in the pool for up to 55s. AWS
+                // ALBs will drop idle connections after 60s and the default
+                // pool idle timeout is 90s; a pool idle timeout longer than
+                // the server timeout can lead to errors upon trying to use
+                // an idle connection.
+                .pool_idle_timeout(Duration::from_secs(55))
+                .connect_timeout(Duration::from_secs(10))
                 .build()
                 .unwrap(),
             host: "https://api.segment.io".to_owned(),

--- a/src/http.rs
+++ b/src/http.rs
@@ -20,10 +20,10 @@ impl Default for HttpClient {
         HttpClient {
             client: reqwest::blocking::Client::builder()
                 // Keep idle connections in the pool for up to 55s. AWS
-                // ALBs will drop idle connections after 60s and the default
-                // pool idle timeout is 90s; a pool idle timeout longer than
-                // the server timeout can lead to errors upon trying to use
-                // an idle connection.
+                // Application Load Balancers will drop idle connections after
+                // 60s and the default pool idle timeout is 90s; a pool idle
+                // timeout longer than the server timeout can lead to errors
+                // upon trying to use an idle connection.
                 .pool_idle_timeout(Duration::from_secs(55))
                 .connect_timeout(Duration::from_secs(10))
                 .build()


### PR DESCRIPTION
See WAR-3318 and the comments I added to the code for an explanation of the benefits of this change.

The 60s value was provided by an engineer at Segment.

This is intended to fix these errors in Sentry, which may lead to us dropping telemetry events: https://sentry.io/organizations/warpdotdev/issues/2910172392/?project=5658526

I tested this change manually with a build of Warp at head, and confirmed that events still get sent to Segment as expected.