### PR TITLE
Require use of HTTPS for the Segment reqwest client.

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -19,7 +19,7 @@ impl Default for HttpClient {
     fn default() -> Self {
         HttpClient {
             client: reqwest::blocking::Client::builder()
-                // Don't allow insecure connections; they will be rejected byu
+                // Don't allow insecure connections; they will be rejected by
                 // the server with a 403 Forbidden.
                 .https_only(true)
                 // Keep idle connections in the pool for up to 55s. AWS

--- a/src/http.rs
+++ b/src/http.rs
@@ -19,6 +19,9 @@ impl Default for HttpClient {
     fn default() -> Self {
         HttpClient {
             client: reqwest::blocking::Client::builder()
+                // Don't allow insecure connections; they will be rejected byu
+                // the server with a 403 Forbidden.
+                .https_only(true)
                 // Keep idle connections in the pool for up to 55s. AWS
                 // Application Load Balancers will drop idle connections after
                 // 60s and the default pool idle timeout is 90s; a pool idle


### PR DESCRIPTION
Segment returns a 403 Forbidden if you try to send a request to http://api.segment.io.  We see this in Sentry occasionally; hopefully forcing use of HTTPS at the reqwest client level will eliminate these.

Not sure why it's happening - I've audited our codebase and there's nowhere that we explicitly try to use the "http://" protocol.

See this cluster: https://sentry.io/organizations/warpdotdev/issues/3192241573/?project=5658526&query=is%3Aunresolved+%22http%3A%2F%2Fapi%22&statsPeriod=14d

I did a quick manual test to ensure that this didn't break telemetry sending, and things worked as expected.