### PR TITLE
Avoid enabling `request`'s `default-tls` feature when default features are disabled.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ optional = true
 version = "2.33"
 
 [dependencies.reqwest]
+default-features = false
 features = ["json"]
 version = "0.11"
 
@@ -36,4 +37,4 @@ version = "1.0.93"
 [features]
 blocking = ["reqwest/blocking"]
 cli = ["clap"]
-default = ["blocking"]
+default = ["blocking", "reqwest/default-tls"]


### PR DESCRIPTION
This allows the `warp` crate, which uses this crate, to choose to use `rustls` instead of the target platform's native SSL/TLS library, by disabling this crate's default features and enabling the appropriate feature for `reqwest`.