### PR TITLE
Update reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ version = "2.33"
 
 [dependencies.reqwest]
 default-features = false
-features = ["json"]
+features = ["json", "macos-system-configuration"]
 version = "0.12.3"
 
 [dependencies.serde]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ version = "2.33"
 [dependencies.reqwest]
 default-features = false
 features = ["json"]
-version = "0.11"
+version = "0.12.3"
 
 [dependencies.serde]
 features = ["derive"]


### PR DESCRIPTION
* Update reqwest to 0.12.3
* We're using an out-of-date version of reqwest, I don't _think_ this is necessarily going to fix https://linear.app/warpdotdev/issue/CORE-1860/gh04470-implementation-of-linux-network-proxy-environment-variables but either way we should upgrade since many versions out of date.
* This PR updates the version we use to be the latest version. Note the 0.12 release put the macos proxy configuration (which Jeff added to request in https://github.com/seanmonstar/reqwest/pull/1955) behind a feature flag that is enabled by default. Since we don't use the default features, I explicitly enabled the `macos-system-configuration` feature. 